### PR TITLE
Remove binlocaldir from local.conf

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -74,9 +74,6 @@ OPTEE_TA_SIGN_KEY ?= "${TOPDIR}/conf/keys/dev.key"
 
 ACCEPT_FSL_EULA = "1"
 
-#Required for building edge-core, should point to the location of mbed tool
-binlocaldir = "/usr/local/bin/"
-
 #Enable debug packages, compilers and debugging tools
 #EXTRA_IMAGE_FEATURES = "dbg-pkgs tools-sdk tools-debug"
 


### PR DESCRIPTION
Should be no longer required for builds