### PR TITLE
Added layers to add Parsec support in Pelion Edge

### DIFF
--- a/conf/bblayers-base.inc
+++ b/conf/bblayers-base.inc
@@ -12,4 +12,5 @@ BASELAYERS = " \
   ${OEROOT}/layers/meta-clang \
   ${OEROOT}/layers/meta-updater \
   ${OEROOT}/layers/meta-security \
+  ${OEROOT}/layers/meta-security/meta-tpm \
 "

--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -23,6 +23,8 @@ BBLAYERS += " \
              ${OEROOT}/layers/meta-pelion-edge \
              ${OEROOT}/layers/meta-pelion-edge/meta-lmp-support \
              ${OEROOT}/layers/meta-mbed-edge \
+             ${OEROOT}/layers/meta-rust \
+             ${OEROOT}/layers/meta-parsec \
              ${OEROOT}/layers/meta-yocto/meta-poky/ \
              ${OEROOT}/layers/meta-arm/meta-arm-autonomy \
             "

--- a/pelion.xml
+++ b/pelion.xml
@@ -4,6 +4,9 @@
   <remote fetch="https://github.com/PelionIoT"
           name="PelionIoT" />
 
+  <remote fetch="ssh://git@github.com/"
+          name="github" />
+
   <project name="meta-mbed-edge"
            path="layers/meta-mbed-edge"
            remote="PelionIoT"
@@ -12,5 +15,15 @@
   <project name="meta-pelion-edge"
            path="layers/meta-pelion-edge"
            remote="PelionIoT"
+           revision="dev" />
+
+  <project name="meta-rust/meta-rust"
+           path="layers/meta-rust"
+           remote="github"
+           revision="9a035fe27262bb23676da9f9f583e3ee39b0a377" />
+
+  <project name="pelioniot/meta-parsec"
+           path="layers/meta-parsec"
+           remote="github"
            revision="dev" />
 </manifest>


### PR DESCRIPTION
Added meta-rust, meta-tpm and meta-parsec layers. 
Use ssh to pull in meta-parsec until it goes public. 