### PR TITLE
conf.local / remove ZU3EG WKS-file

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -97,8 +97,6 @@ ENABLE_SERIAL_CONSOLE = "1"
 # edge-kubelet is a modified version of Kubernetes' kubelet to enable kubelet interact with the Pelion cloud services
 PREFERRED_RPROVIDER_kubelet = "kubelet"
 
-WKS_FILES_uz = "sdimage-uz-sota-config.wks.in"
-
 # if persistent /var/log is desired, set the following to "no"
 # persistent logging is required to enable Journald's Forware Secure Sealing (FSS) feature
 VOLATILE_LOG_DIR = "no"


### PR DESCRIPTION
It is not required as the wks-file gets now correctly pulled in via
the PR 288 in meta-pelion-edge.

https: //github.com/PelionIoT/meta-pelion-edge/pull/288

Change-Id: If95f43e753b0f50c5bd0d6dd69f5ac12678a96de