### PR TITLE
Change default image file name for MFG tool

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -100,3 +100,6 @@ PREFERRED_RPROVIDER_kubelet = "kubelet"
 # if persistent /var/log is desired, set the following to "no"
 # persistent logging is required to enable Journald's Forware Secure Sealing (FSS) feature
 VOLATILE_LOG_DIR = "no"
+
+# Set default Pelion image name to mfg tool
+MFGTOOL_FLASH_IMAGE = "console-image-lmp"


### PR DESCRIPTION
With this change mfgtool will generate full_image.uuu to use file name `console-image-lmp-<machine>.wic`