### PR TITLE
Remove meta-arm-autonomy layer

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -26,5 +26,4 @@ BBLAYERS += " \
              ${OEROOT}/layers/meta-rust \
              ${OEROOT}/layers/meta-parsec \
              ${OEROOT}/layers/meta-yocto/meta-poky/ \
-             ${OEROOT}/layers/meta-arm/meta-arm-autonomy \
             "


### PR DESCRIPTION
This was earlier added to add dhcp client but DHCP currently seems to work even without this layer.
This layer also causes issues for building mfgfiles for some targets.