### PR TITLE
config: add dependency to pc-ble-driver into config, default off

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -94,6 +94,9 @@ GOVERSION = "1.15%"
 #Enables serial console for raspberry pi
 ENABLE_SERIAL_CONSOLE = "1"
 
+# Uncomment following line to get pc-ble-driver into image.
+# IMAGE_INSTALL_append = " pc-ble-driver"
+
 # edge-kubelet is a modified version of Kubernetes' kubelet to enable kubelet interact with the Pelion cloud services
 PREFERRED_RPROVIDER_kubelet = "kubelet"
 


### PR DESCRIPTION
Add dependency for the pc-ble-driver into comments, so one can
"easily" enable it on the build if needed. Note: the driver itself
works equally on a USB connected dongle or hardwired module in a
board, so it may not make sense to tie it to a specific board at
all. Let's just make it possible for user to choose if the module
is available and needed.

Related change: https://github.com/PelionIoT/meta-pelion-edge/pull/303