### PR TITLE
Add pkcs11 provider.

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -114,4 +114,5 @@ MFGTOOL_FLASH_IMAGE = "console-image-lmp"
 
 
 # Set default for the PARSEC Provider to be SOFTWARE_TPM.
+# Allowed values are SOFTWARE_TPM, HARDWARE_TPM or PKCS11
 PARSEC_PROVIDER ?= "SOFTWARE_TPM"

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -111,3 +111,6 @@ VOLATILE_LOG_DIR = "no"
 
 # Set default Pelion image name to mfg tool
 MFGTOOL_FLASH_IMAGE = "console-image-lmp"
+
+# Set default for the PARSEC Provider to be SOFTWARE_TPM.
+PARSEC_PROVIDER ?= "SOFTWARE_TPM"

--- a/pelion.xml
+++ b/pelion.xml
@@ -15,10 +15,10 @@
   <project name="meta-pelion-edge"
            path="layers/meta-pelion-edge"
            remote="PelionIoT"
-           revision="add_pkcs11_provider" />
+           revision="750b7df6d52ece28c923e6e185ccdf5e64720ce6" />
 
   <project name="meta-parsec"
            path="layers/meta-parsec"
            remote="PelionIoT"
-           revision="add_pkcs11_provider" />
+           revision="afa9bb3a6488ad6f7f1a3a78502ff1010b431426" />
 </manifest>

--- a/pelion.xml
+++ b/pelion.xml
@@ -15,10 +15,10 @@
   <project name="meta-pelion-edge"
            path="layers/meta-pelion-edge"
            remote="PelionIoT"
-           revision="6f64297d29591daa458e0a9b05c8546a0ab576b3" />
+           revision="add_pkcs11_provider" />
 
   <project name="meta-parsec"
            path="layers/meta-parsec"
            remote="PelionIoT"
-           revision="b70eda4096c548de5087343a2d47fdb0edaf3344" />
+           revision="add_pkcs11_provider" />
 </manifest>


### PR DESCRIPTION
Added the PKCS11 provider as an alternative to the SW TPM provider.

The provider to be used is controlled using the PARSEC_PROVIDER variable in local.conf

This can either be SOFTWARE_TPM or PKCS11.

The relevant files will then be selected based upon that.