### PR TITLE
Fix ostree upgrades.

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -65,7 +65,7 @@ MODSIGN_KEY_DIR ?= "${TOPDIR}/conf/keys"
 #
 # Supported key type: RSA 2048
 UBOOT_SIGN_KEYDIR ??= "${TOPDIR}/conf/keys"
-UBOOT_SIGN_KEYNAME ?= "ubootdev"
+UBOOT_SIGN_KEYNAME ?= "dev"
 #UBOOT_SIGN_ENABLE ?= "1"
 
 #
@@ -75,7 +75,7 @@ UBOOT_SIGN_KEYNAME ?= "ubootdev"
 # repository, which should only be used for development purposes. To use a
 # custom signing key just generate a custom RSA 2048 key (PEM format) and
 # set via the OPTEE_TA_SIGN_KEY variable.
-OPTEE_TA_SIGN_KEY ??= "${TOPDIR}/conf/keys/opteedev.key"
+OPTEE_TA_SIGN_KEY ??= "${TOPDIR}/conf/keys/dev.key"
 
 ACCEPT_FSL_EULA = "1"
 


### PR DESCRIPTION
Reverted to use the same keys as LMP v82 so the fit image in the upgrade
is signed with tha same key that a deployed uboot is expecting.