### PR TITLE
Remove the default for PARSEC_PROVIDER.

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -111,8 +111,3 @@ VOLATILE_LOG_DIR = "no"
 
 # Set default Pelion image name to mfg tool
 MFGTOOL_FLASH_IMAGE = "console-image-lmp"
-
-
-# Set default for the PARSEC Provider to be SOFTWARE_TPM.
-# Allowed values are SOFTWARE_TPM, HARDWARE_TPM or PKCS11
-PARSEC_PROVIDER ?= "SOFTWARE_TPM"


### PR DESCRIPTION
Removed the default for PARSEC_PROVIDER - this has moved to meta-pelion-edge and done for each device.