### PR TITLE
bitbake update to 3.3.4 - GitHub brownout fix

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="731fb52eb03338c0bdb2a2256c22c64c22bcbace"/>
+  <project name="bitbake" revision="0fe1a9e2d2e33f80d807cefc7a23df4a5f760c74"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>


### PR DESCRIPTION
We are especially interested in the fix Richard Purdie made for the
GitHub brownouts, where they (in name of security) randombly block
plain text git-protocol (one has to use either https or ssh).

fetch/git: Handle github dropping git:// support
https://github.com/openembedded/bitbake/commits/yocto-3.3.4

See the GitHub article at

https: //github.blog/2021-09-01-improving-git-protocol-security-github/

Change-Id: If118adbe00c7e8e81b8f3f07b21865f9993fc4cd